### PR TITLE
Check headers before setting status code (#6)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -73,6 +73,15 @@ async function errorHandler(err) {
   // check if we're about to go into a possible endless redirect loop
   const noReferrer = this.get('Referrer') === '';
 
+  // nothing we can do here other
+  // than delegate to the app-level
+  // handler and log.
+  if (this.headerSent || !this.writable) {
+    debug('headers were already sent, returning early');
+    err.headerSent = true;
+    return;
+  }
+
   // populate the status and body with `boom` error message payload
   // (e.g. you can do `ctx.throw(404)` and it will output a beautiful err obj)
   err.status = err.status || 500;
@@ -84,15 +93,6 @@ async function errorHandler(err) {
   debug('status code was %d', this.status);
 
   this.app.emit('error', err, this);
-
-  // nothing we can do here other
-  // than delegate to the app-level
-  // handler and log.
-  if (this.headerSent || !this.writable) {
-    debug('headers were already sent, returning early');
-    err.headerSent = true;
-    return;
-  }
 
   // fix page title and description
   this.state.meta = this.state.meta || {};

--- a/test/test.js
+++ b/test/test.js
@@ -34,6 +34,13 @@ test.beforeEach(t => {
     router.get(`/${code}`, ctx => ctx.throw(code));
   });
 
+  router.get('/break-headers-sent', ctx => {
+    ctx.type = 'text/html';
+    ctx.body = 'foo';
+    ctx.res.end();
+    ctx.throw(404);
+  });
+
   // initialize routes on the app
   t.context.app.use(router.routes());
 
@@ -53,4 +60,12 @@ _.each(['text/html', 'application/json', 'text/plain'], type => {
         .end(t.end);
     });
   });
+});
+
+test.cb("Won't throw after sending headers", t => {
+  request(t.context.app.listen())
+    .get('/break-headers-sent')
+    .set('Accept', 'text/html')
+    .expect(200)
+    .end(t.end);
 });


### PR DESCRIPTION
Koa's reponse status code had a setter that would check if the headers were already sent:

https://github.com/koajs/koa/blob/6baa41178d3930df399fb367dbc3d73890760e02/lib/context.js#L111-L124

We were hitting that error here, before the "headers sent" check:

https://github.com/ladjs/koa-better-error-handler/blob/master/src/index.js#L78

I didn't match [this code](https://github.com/koajs/koa/blob/6baa41178d3930df399fb367dbc3d73890760e02/lib/context.js#L111-L124) because that would break it again, cause we would need to set the status before `emit('error')` (which would break).